### PR TITLE
Use a global logger so the logging level can be set at the package level

### DIFF
--- a/purview/__init__.py
+++ b/purview/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+import logging
+log = logging.getLogger('purview')

--- a/purview/utils/general.py
+++ b/purview/utils/general.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0+
 
 import re
-import logging
 from datetime import datetime
 
-log = logging.getLogger(__name__)
+from purview import log
 
 
 def timestamp_to_datetime(timestamp):

--- a/purview/utils/teiid.py
+++ b/purview/utils/teiid.py
@@ -2,9 +2,8 @@
 # Inspired from the MARS project
 
 import psycopg2
-import logging
 
-log = logging.getLogger(__name__)
+from purview import log
 
 
 class Teiid(object):

--- a/scrapers/koji.py
+++ b/scrapers/koji.py
@@ -3,10 +3,7 @@ from scrapers.base import BaseScraper
 from purview.models.koji import KojiBuild, KojiTask, KojiTag
 from purview.models.user import User
 import purview.utils.general as utils
-
-import logging
-
-log = logging.getLogger(__name__)
+from purview import log
 
 
 class KojiScraper(BaseScraper):

--- a/scripts/scrape.py
+++ b/scripts/scrape.py
@@ -10,8 +10,9 @@ sys.path.insert(1, os.path.abspath(os.path.join(sys.path[0], '..')))
 
 import scrapers  # noqa: E402
 
-log = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(format='[%(filename)s:%(lineno)s:%(funcName)s] %(message)s')
+log = logging.getLogger('purview')
+log.setLevel(logging.DEBUG)
 
 parser = argparse.ArgumentParser(description='Run a scraper')
 parser.add_argument('scraper', type=str, help='The scraper to run')


### PR DESCRIPTION
Running the scraper script in master was very noisy (it included debug logs from requests, nemodel, etc.). This should fix that.