### PR TITLE
Order by build.id in the Koji scraper

### DIFF
--- a/scrapers/koji.py
+++ b/scrapers/koji.py
@@ -34,6 +34,7 @@ class KojiScraper(BaseScraper):
             LEFT JOIN events ON build.create_event = events.id
             LEFT JOIN package ON build.pkg_id = package.id
             WHERE events.time IS NOT NULL AND events.time >= '{}'
+            ORDER BY build.id
             """.format(start_date)
 
         return self.teiid.query(sql=sql_query)


### PR DESCRIPTION
This is nice to have because when the scraper dies due to TEIID going down, we then modify the SQL query to return the last build ID processed and higher to not return already processed data.