### PR TITLE
Don't require certain properties on the DistGitCommit model

### DIFF
--- a/purview/models/distgit.py
+++ b/purview/models/distgit.py
@@ -36,8 +36,8 @@ class DistGitPush(PurviewStructuredNode):
 
 
 class DistGitCommit(PurviewStructuredNode):
-    author_date = DateTimeProperty(required=True)
-    commit_date = DateTimeProperty(required=True)
+    author_date = DateTimeProperty()
+    commit_date = DateTimeProperty()
     hash_ = UniqueIdProperty(db_property='hash')
     log_message = StringProperty()
     authors = RelationshipTo('.user.User', 'AUTHORED_BY')

--- a/scrapers/distgit.py
+++ b/scrapers/distgit.py
@@ -78,7 +78,7 @@ class DistGitScraper(BaseScraper):
             branch_name = result['ref'].rsplit('/', 1)[1]
             branch = DistGitBranch.get_or_create(
                 {'name': branch_name}, relationships=repo.branches)[0]
-            commit = DistGitCommit.get_or_create({
+            commit = DistGitCommit.create_or_update({
                 'author_date': result['author_date'],
                 'commit_date': result['commit_date'],
                 'hash_': result['sha'],


### PR DESCRIPTION
Since the Koji scraper can be run before the dist-git scraper, it may create some DistGitCommit nodes in Neo4j since they don't exist yet, but it also doesn't have enough info to fill out the current required properties. Instead, a DistGitCommit node should be able to be created with just the commit hash. The dist-git scraper can then fill out the rest later when it's run.