### PR TITLE
Accept other Git URI formats from Koji build tasks

### DIFF
--- a/scrapers/koji.py
+++ b/scrapers/koji.py
@@ -129,7 +129,7 @@ class KojiScraper(BaseScraper):
                 commit_hash = None
                 for child in xml_root.iter('string'):
                     if child.text.startswith('git://'):
-                        commit_hash = child.text.rsplit('?#', 1)[1]
+                        commit_hash = child.text.rsplit('#', 1)[1]
                         break
             else:
                 # Continue if the task_id is None


### PR DESCRIPTION
Some Git URIs for some reason only have `#` instead of `?#` between the repo and the commit hash.