### PR TITLE
Make the configuration more flexible

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,8 +1,6 @@
 FROM fedora:28
 LABEL maintainer="Factory 2.0"
 
-# Mount the config file here
-VOLUME /etc/purview
 WORKDIR /src
 RUN dnf -y install \
     --setopt=deltarpm=0 \

--- a/purview/app.py
+++ b/purview/app.py
@@ -34,6 +34,8 @@ def load_config(app):
 
     if os.environ.get('SECRET_KEY'):
         app.config['SECRET_KEY'] = os.environ['SECRET_KEY']
+    if os.environ.get('NEO4J_URI'):
+        app.config['NEO4J_URI'] = os.environ['NEO4J_URI']
 
 
 def insert_headers(response):

--- a/purview/app.py
+++ b/purview/app.py
@@ -29,7 +29,7 @@ def load_config(app):
 
     app.config.from_object(default_config_obj)
     config_file = os.environ.get('PURVIEW_CONFIG', default_config_file)
-    if config_file:
+    if config_file and os.path.isfile(config_file):
         app.config.from_pyfile(config_file)
 
     if os.environ.get('SECRET_KEY'):


### PR DESCRIPTION
This will allow us to configure the app in OpenShift via environment variables instead of a config file. This makes passing in secrets easier.