### PR TITLE
Install Purview in the Docker image

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -15,5 +15,6 @@ RUN dnf -y install \
 # This will allow a non-root user to install a custom root CA at run-time
 RUN chmod 777 /etc/pki/tls/certs/ca-bundle.crt
 COPY . .
+RUN python3 setup.py install --prefix /usr
 USER 1001
 CMD ["/usr/bin/bash", "-c", "docker/install-ca.sh && exec gunicorn-3 --bind 0.0.0.0:8080 --access-logfile=- --enable-stdio-inheritance purview.wsgi:app"]


### PR DESCRIPTION
Install Purview in the Docker image so that the about API endpoint shows the version.