### PR TITLE
Clear some vars out of RAM in the dist-git scraper

### DIFF
--- a/scrapers/distgit.py
+++ b/scrapers/distgit.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import re
 from multiprocessing.dummy import Pool as ThreadPool
 from os import getenv
+import gc
 
 from builtins import bytes
 from bs4 import BeautifulSoup
@@ -143,6 +144,10 @@ class DistGitScraper(BaseScraper):
                 commit.resolved_bugs.connect(bug)
             elif result['bugzilla_type'] == 'reverted':
                 commit.reverted_bugs.connect(bug)
+            # This is no longer needed so it can be cleared to save RAM
+            del repos_info
+            # Force RAM to be cleared on every iteration of the loop
+            gc.collect()
 
     def get_distgit_data(self, since):
         """


### PR DESCRIPTION
I used to delete only one variable in the loop which I would think would cause Python to release the memory back to the OS but it didn't seem to be the case because after running this scraper for 14 hours, it used up all of the 2GiB I gave it in OpenShift. This PR deletes another variable and runs `gc.collect()` after every iteration in the loop in the hopes that Python will release more RAM back to the OS.