### PR TITLE
Decompose the beautiful soup after use

### DIFF
--- a/scrapers/distgit.py
+++ b/scrapers/distgit.py
@@ -231,6 +231,7 @@ class DistGitScraper(BaseScraper):
             if all(data_found.values()):
                 break
 
+        soup.decompose()
         return rv
 
     @staticmethod


### PR DESCRIPTION
This should effectively delete the beautiful soup object and all references to it so it doesn't leak memory. If this fails, I will convert the multi-threading to multi-processing.